### PR TITLE
Removed escape char from strings with a single quote

### DIFF
--- a/sigma/backends/cortexxdr/cortexxdr.py
+++ b/sigma/backends/cortexxdr/cortexxdr.py
@@ -47,10 +47,10 @@ class CortexXDRBackend(TextQueryBackend):
     field_escape_pattern : ClassVar[Pattern] = re.compile("\\s")   # All matches of this pattern are prepended with the string contained in field_escape.
 
     ## Values
-    str_quote         : ClassVar[str] = '"""'     # string quoting character (added as escaping character)
+    str_quote         : ClassVar[str] = '"'     # string quoting character (added as escaping character)
     str_quote_pattern : ClassVar[Optional[Pattern]] = re.compile("^ENUM\.[A-Z_]{1,}$")      # Quote string values that match (or don't match) this pattern
     str_quote_pattern_negation : ClassVar[bool] = True  # Negate str_quote_pattern result
-    escape_char       : ClassVar[str] = "\\"    # Escaping character for special characters inside string
+    #escape_char       : ClassVar[str] = "\\"    # Escaping character for special characters inside string
     wildcard_multi    : ClassVar[str] = "*"     # Character used as multi-character wildcard
     wildcard_single   : ClassVar[str] = "*"     # Character used as single-character wildcard
     add_escaped       : ClassVar[str] = "\\"    # Characters quoted in addition to wildcards and string quote


### PR DESCRIPTION
In XQL using a single quote looks for the exact string so an scape char is not needed.

![image](https://github.com/user-attachments/assets/ab4b90e8-880d-4ca5-bc23-6c6aa1d993e0)

As seen here when using a single double quote with an escape char the query does not parse it correctly and will match on `\\` and not `\` as expected (As seen in test and test3 in the table).